### PR TITLE
feat: add support for additional service accounts in virt-api

### DIFF
--- a/docs/additional-service-accounts.md
+++ b/docs/additional-service-accounts.md
@@ -1,0 +1,86 @@
+# 配置额外的服务账户权限
+
+KubeVirt 的 virt-api 组件现在支持通过命令行参数配置额外的服务账户，这些服务账户将被允许更新 VMI 状态。
+
+## 背景
+
+默认情况下，只有以下 KubeVirt 系统服务账户可以更新 VMI 状态：
+- `kubevirt-apiserver`
+- `kubevirt-controller` 
+- `kubevirt-handler`
+
+## 新增功能
+
+通过 `--additional-service-accounts` 参数，您可以添加其他服务账户到允许列表中。
+
+## 使用方法
+
+### 1. 命令行参数
+
+```bash
+# 启动 virt-api 时添加额外的服务账户
+virt-api --additional-service-accounts=myapp:myuser --additional-service-accounts=otherns:otheruser
+
+# 或者使用完整格式
+virt-api --additional-service-accounts=system:serviceaccount:myapp:myuser
+```
+
+### 2. 参数格式
+
+支持两种格式：
+- **简短格式**: `namespace:serviceaccount` (自动添加 `system:serviceaccount:` 前缀)
+- **完整格式**: `system:serviceaccount:namespace:serviceaccount`
+
+### 3. 多个服务账户
+
+可以多次使用该参数来添加多个服务账户：
+```bash
+virt-api \
+  --additional-service-accounts=app1:user1 \
+  --additional-service-accounts=app2:user2 \
+  --additional-service-accounts=system:serviceaccount:app3:user3
+```
+
+## 示例场景
+
+### 场景 1: 自定义应用需要更新 VMI 状态
+```bash
+virt-api --additional-service-accounts=myapp:vmi-manager
+```
+
+### 场景 2: 多个命名空间的应用
+```bash
+virt-api \
+  --additional-service-accounts=monitoring:metrics-collector \
+  --additional-service-accounts=logging:log-aggregator
+```
+
+### 场景 3: 使用完整格式
+```bash
+virt-api --additional-service-accounts=system:serviceaccount:custom:operator
+```
+
+## 验证配置
+
+启动后，virt-api 会在日志中显示添加的额外服务账户：
+
+```
+I0123 10:00:00.000000       1 api.go:207] Added additional service account: system:serviceaccount:myapp:myuser
+I0123 10:00:00.000001       1 api.go:207] Added additional service account: system:serviceaccount:otherns:otheruser
+```
+
+## 注意事项
+
+1. **安全性**: 只有真正需要更新 VMI 状态的服务账户才应该被添加
+2. **权限范围**: 这些服务账户只能更新 VMI 状态，不能修改其他字段
+3. **重启要求**: 修改此参数后需要重启 virt-api 组件
+4. **持久性**: 此配置不会持久化，重启后需要重新指定
+
+## 故障排除
+
+如果遇到权限问题，请检查：
+1. 服务账户名称是否正确
+2. 命名空间是否存在
+3. 服务账户是否有相应的 RBAC 权限
+4. virt-api 日志中是否显示了添加的服务账户
+

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -142,6 +143,8 @@ type virtAPIApp struct {
 	reInitChan chan string
 
 	kubeVirtServiceAccounts map[string]struct{}
+	// Additional service accounts that are allowed to update VMI status
+	additionalServiceAccounts []string
 }
 
 var (
@@ -196,6 +199,16 @@ func (app *virtAPIApp) Execute() {
 	}
 
 	app.kubeVirtServiceAccounts = webhooks.KubeVirtServiceAccounts(app.namespace)
+
+	// Add additional service accounts configured via command line arguments
+	for _, sa := range app.additionalServiceAccounts {
+		// If user doesn't provide full format, automatically add prefix
+		if !strings.HasPrefix(sa, "system:serviceaccount:") {
+			sa = fmt.Sprintf("system:serviceaccount:%s", sa)
+		}
+		app.kubeVirtServiceAccounts[sa] = struct{}{}
+		log.Log.Infof("Added additional service account: %s", sa)
+	}
 
 	app.ConfigureOpenAPIService()
 	app.reInitChan = make(chan string, 10)
@@ -1203,6 +1216,9 @@ func (app *virtAPIApp) AddFlags() {
 		"Private key for the client certificate used to prove the identity of the virt-api when it must call virt-handler during a request")
 	flag.BoolVar(&app.externallyManaged, "externally-managed", false,
 		"Allow intermediate certificates to be used in building up the chain of trust when certificates are externally managed")
+	// Support for configuring additional service accounts
+	flag.StringSliceVar(&app.additionalServiceAccounts, "additional-service-accounts", []string{},
+		"Additional service accounts that are allowed to update VMI status (can be specified multiple times)")
 }
 
 // GetGsInfo returns the libguestfs-tools image information based on the KubeVirt installation in the namespace.

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -21,6 +21,7 @@ package virt_api
 
 import (
 	"errors"
+	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -222,6 +223,26 @@ var _ = Describe("Virt-api", func() {
 			app.AddFlags()
 			Expect(app.SwaggerUI).To(Equal("third_party/swagger-ui"))
 			Expect(app.SubresourcesOnly).To(BeFalse())
+			Expect(app.consoleServerPort).To(Equal(DefaultConsoleServerPort))
+			Expect(app.caConfigMapName).To(Equal(defaultCAConfigMapName))
+			Expect(app.tlsCertFilePath).To(Equal(defaultTlsCertFilePath))
+			Expect(app.tlsKeyFilePath).To(Equal(defaultTlsKeyFilePath))
+			Expect(app.handlerCertFilePath).To(Equal(defaultHandlerCertFilePath))
+			Expect(app.handlerKeyFilePath).To(Equal(defaultHandlerKeyFilePath))
+			Expect(app.externallyManaged).To(BeFalse())
+			Expect(app.additionalServiceAccounts).To(BeEmpty())
+		})
+
+		It("should support additional service accounts flag", func() {
+			app.AddFlags()
+
+			// Mock command line arguments
+			os.Args = []string{"virt-api", "--additional-service-accounts=myapp:myuser", "--additional-service-accounts=system:serviceaccount:otherns:otheruser"}
+
+			// Re-parse flags
+			flag.Parse()
+
+			Expect(app.additionalServiceAccounts).To(ContainElements("myapp:myuser", "system:serviceaccount:otherns:otheruser"))
 		})
 
 	})


### PR DESCRIPTION
- Add --additional-service-accounts command line flag to allow custom service accounts to update VMI status
- Support both short format (namespace:serviceaccount) and full format (system:serviceaccount:namespace:serviceaccount)
- Automatically add system:serviceaccount: prefix for short format inputs
- Add comprehensive documentation with usage examples and troubleshooting guide
- Include unit tests for the new functionality
- Maintain backward compatibility with existing KubeVirt service accounts

This enhancement enables external applications and operators to interact with KubeVirt VMI resources without requiring full cluster-admin privileges.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

